### PR TITLE
Added optional language attribute to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ import 'package:geocoder2/geocoder2.dart';
     print(data.street_number);
 ```
 
+Both methods also have an optional ```language``` parameter to request the results in a specific language.
+Here is the [list of supported language codes](https://developers.google.com/maps/faq#languagesupport).
+
 ### Buy Me A Coffee
 
 <a href="https://www.buymeacoffee.com/flutterbuddy">

--- a/lib/src/geocoder2.dart
+++ b/lib/src/geocoder2.dart
@@ -4,14 +4,14 @@ import 'package:http/http.dart' as http;
 
 class Geocoder2 {
   ///Get City ,country , postalCode,state,streetNumber and countryCode from latitude and longitude
-  static Future<GeoData> getDataFromCoordinates(
-      {required double latitude,
-      required double longitude,
-      required String googleMapApiKey}) async {
-    var request = http.Request(
-        'GET',
-        Uri.parse(
-            'https://maps.googleapis.com/maps/api/geocode/json?latlng=$latitude,$longitude&key=$googleMapApiKey'));
+  static Future<GeoData> getDataFromCoordinates({
+    required double latitude,
+    required double longitude,
+    required String googleMapApiKey,
+    String? language,
+  }) async {
+    var url = language != null ? 'https://maps.googleapis.com/maps/api/geocode/json?latlng=$latitude,$longitude&key=$googleMapApiKey&language=$language' : 'https://maps.googleapis.com/maps/api/geocode/json?latlng=$latitude,$longitude&key=$googleMapApiKey';
+    var request = http.Request('GET', Uri.parse(url));
     http.StreamedResponse response = await request.send();
     if (response.statusCode == 200) {
       String data = await response.stream.bytesToString();
@@ -59,15 +59,15 @@ class Geocoder2 {
       return null as GeoData;
     }
   }
+
   ///Get City ,country , postalCode,state,streetNumber and countryCode from address like "277 Bedford Ave, Brooklyn, NY 11211, USA"
   static Future<GeoData> getDataFromAddress({
     required String address,
     required String googleMapApiKey,
+    String? language,
   }) async {
-    var request = http.Request(
-        'GET',
-        Uri.parse(
-            'https://maps.googleapis.com/maps/api/geocode/json?address=$address&key=$googleMapApiKey'));
+    var url = language != null ? 'https://maps.googleapis.com/maps/api/geocode/json?address=$address&key=$googleMapApiKey&language=$language' : 'https://maps.googleapis.com/maps/api/geocode/json?address=$address&key=$googleMapApiKey';
+    var request = http.Request('GET', Uri.parse(url));
 
     http.StreamedResponse response = await request.send();
 
@@ -112,7 +112,7 @@ class Geocoder2 {
         postalCode: postalCode,
         state: state,
         countryCode: countryCode,
-        street_number: streetNumber,
+        streetNumber: streetNumber,
       );
     } else {
       return null as GeoData;

--- a/lib/src/modal/data.dart
+++ b/lib/src/modal/data.dart
@@ -14,10 +14,10 @@ class GeoData {
   String address;
   String city;
   String country;
-  String postalCode;
-  String state;
   double latitude;
   double longitude;
-  String streetNumber;
+  String postalCode;
+  String state;
   String countryCode;
+  String streetNumber;
 }


### PR DESCRIPTION
On `data.dart` I only changed the order of some variables in the constructor to match the order of the main variables.

I also updated the `README.md` file explaining the optional language attribute

And of course, I added the optional `String? language` variable to both methods.
It will check `if language is null` and pick the original URL if `true` or the new URL `...&language=$language` if `false`.

Also on the `return GeoData()` method I fixed `street_number` to `streetNumber` as it is the correct variable name in the model and it was throwing a compile error.